### PR TITLE
Add <meta charset="utf-8"> to base template

### DIFF
--- a/Public/styles/app.css
+++ b/Public/styles/app.css
@@ -1,19 +1,20 @@
-body, html {
-	height: 100%;
+body,
+html {
+    height: 100%;
 }
 
 body {
-	font-family: sans-serif;
+    font-family: sans-serif;
 }
 
 div.welcome {
-	height: 100%;
-	text-align: center;
+    height: 100%;
+    text-align: center;
 }
 
 div.welcome img {
-	position: relative;
-  	top: 50%;
-  	transform: translateY(-50%);
-	width: 300px;
+    position: relative;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 300px;
 }

--- a/Resources/Views/base.leaf
+++ b/Resources/Views/base.leaf
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html>
 <head>
-        <meta charset="utf-8">
-	<title>#get(title)</title>
-	<link rel="stylesheet" href="/styles/app.css">
+    <meta charset="utf-8">
+    <title>#get(title)</title>
+    <link rel="stylesheet" href="/styles/app.css">
 </head>
 <body>
     #get(body)

--- a/Resources/Views/base.leaf
+++ b/Resources/Views/base.leaf
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+        <meta charset="utf-8">
 	<title>#get(title)</title>
 	<link rel="stylesheet" href="/styles/app.css">
 </head>

--- a/Resources/Views/hello.leaf
+++ b/Resources/Views/hello.leaf
@@ -1,7 +1,7 @@
 #set("title") { Hello, #(name)! }
 
 #set("body") {
-	<h1>Hello, #(name)!</h1>
+    <h1>Hello, #(name)!</h1>
 }
 
 #embed("base")

--- a/Resources/Views/welcome.leaf
+++ b/Resources/Views/welcome.leaf
@@ -1,9 +1,9 @@
 #set("title") { It works }
 
 #set("body") {
-	<div class="welcome">
-		<img src="/images/it-works.png">
-	</div>
+    <div class="welcome">
+        <img src="/images/it-works.png">
+    </div>
 }
 
 #embed("base")


### PR DESCRIPTION
It's important to specify an explicit character encoding on every webpage in order for it to render properly.

According to the [Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta):

> The `<meta>` element declaring the encoding must be inside the `<head>` element and within the first 1024 bytes of the HTML as some browsers only look at those bytes before choosing an encoding.

This PR adds the necessary tag to the base template.