### PR TITLE
Make docker build faster by ignoring .build folder

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.build/
+.swiftpm/

--- a/manifest.yml
+++ b/manifest.yml
@@ -67,4 +67,4 @@ files:
   - file: web.Dockerfile
     dynamic: true
   - .gitignore
-
+  - .dockerignore


### PR DESCRIPTION
Before the Docker starts to build the image it copies all files into its context. By adding `.build` and `.swiftpm` to `.dockerignore` this process will be a lot faster resulting in faster Docker image builds if those folders exist.