### PR TITLE
Fix for use-case where LOG_LEVEL is not overridden

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - db{{/fluent}}
     ports:
       - '8080:80'
-    command: ["serve", "--env", "production", "--hostname", "0.0.0.0", "--port", "80", "--log", $LOG_LEVEL]{{#fluent}}
+    command: ["serve", "--env", "production", "--hostname", "0.0.0.0", "--port", "80", "--log", ${LOG_LEVEL:-info}]{{#fluent}}
   migrate:
     image: {{name}}:latest
     build:
@@ -44,7 +44,7 @@ services:
       <<: *shared_environment
     depends_on:
       - db
-    command: ["migrate", "--yes", "--log", $LOG_LEVEL]  
+    command: ["migrate", "--yes", "--log", ${LOG_LEVEL:-info}]  
   revert:
     image: {{name}}:latest
     build:
@@ -53,7 +53,7 @@ services:
       <<: *shared_environment
     depends_on:
       - db
-    command: ["migrate", "--revert", "--yes", "--log", $LOG_LEVEL]{{/fluent}}{{#fluent.db.is_postgres}}
+    command: ["migrate", "--revert", "--yes", "--log", ${LOG_LEVEL:-info}]{{/fluent}}{{#fluent.db.is_postgres}}
   db:
     image: postgres:12.1-alpine
     volumes:


### PR DESCRIPTION
I see the appeal in ditching the entrypoint script since it only existed to allow running things without `LOG_LEVEL` overridden, but you'll need these changes in here or else the user _must_ defined `LOG_LEVEL` on their machine to run things. One thing that can be confusing is where ENV vars come from in the context of docker-compose.

Although your line under `shared_environment` successfuly sets `LOG_LEVEL` _within_ those services, the references to `$LOG_LEVEL` in the run commands are resolved by Docker when reading this compose file and refer to the host environment, not the service's soon-to-be environment.