### PR TITLE
don't give migrate/revert any replicas in swarms

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,9 @@ services:
       <<: *shared_environment
     depends_on:
       - db
-    command: ["migrate", "--yes", "--log", $LOG_LEVEL]  
+    command: ["migrate", "--yes", "--log", $LOG_LEVEL]
+    deploy:
+      replicas: 0
   revert:
     image: {{name}}:latest
     build:
@@ -54,6 +56,8 @@ services:
     depends_on:
       - db
     command: ["migrate", "--revert", "--yes", "--log", $LOG_LEVEL]{{/fluent}}{{#fluent.db.is_postgres}}
+    deploy:
+      replicas: 0
   db:
     image: postgres:12.1-alpine
     volumes:


### PR DESCRIPTION
The replica count is important for swarm deploys because as-is a swarm deploy will result in running both migrate and revert (doing both in an undefined order no less). With replicas specified as 0, you must choose to scale those services up in swarm environment.