### PR TITLE
Adjust for local dev env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
     ports:
       - '5432:5432'{{/fluent.db.is_postgres}}{{#fluent.db.is_mysql}}
   db:
-    image: mysql/mysql-server:8.0
+    image: mysql:8.0
     volumes:
       - db_data:/var/lib/mysql
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,8 @@
 # Docker Compose file for Vapor
 #
+# IMPORTANT: This file is not intended to suggest 
+#   best practices for a production deploy!
+#
 # Install Docker on your system to run and test
 # your Vapor app in a production-like environment.
 #


### PR DESCRIPTION
In a dev environment it is _likely_ preferable not to require the user to bind mount their own SSL cert into the mysql service. One of the big differences between the `mysql/mysql-server` and `mysql` docker images is that the latter has the ability to generate a self-signed cert when it starts up.

Of course, for Vapor to communicate with it, the mysql config still needs to be modified to not use a certificate signing authority.