### PR TITLE
Fixes and Vapor Cloud tidy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ================================
 # Build image
 # ================================
-FROM vapor/swift:5.1 as build
+FROM vapor/swift:5.2 as build
 WORKDIR /build
 
 # Copy entire repo into container

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update -y \
 # Compile with optimizations
 RUN swift build \
 	--enable-test-discovery \
-	-c release
+	-c release \
 	-Xswiftc -g
 
 # ================================

--- a/cloud.yml
+++ b/cloud.yml
@@ -1,3 +1,0 @@
-type: "vapor"
-swift_version: "4.1.0"
-run_parameters: "serve --port 8080 --hostname 0.0.0.0"


### PR DESCRIPTION
This PR:
* Updates the Dockerfile to use Swift 5.2 as it's now required by Vapor 4
* Fixes an unescaped line break in the Dockerfile which would cause `docker build` to fail
* Removes `cloud.yml` as Vapor Cloud is no longer a thing after February 29th