### PR TITLE
Add LinuxMain.swift to the template

### DIFF
--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,0 +1,1 @@
+#error("Run the tests with `swift test --enable-test-discovery`.")

--- a/manifest.yml
+++ b/manifest.yml
@@ -64,6 +64,7 @@ files:
       - folder: AppTests
         files:
           - AppTests.swift
+      - LinuxMain.swift
   - file: Dockerfile
     dynamic: true
   - file: docker-compose.yml


### PR DESCRIPTION
Testing a new Vapor app on Linux does not works with `swift test` and gives the following error:
`error: missing LinuxMain.swift file in the Tests directory`

The solution is to add an option to the tests: `swift test --enable-test-discovery`. This option is available since Swift 5.1 [Test discovery on Linux](https://forums.swift.org/t/test-discovery-on-linux/26203/23)

With this pull request, the error message gives information on how we should run tests on Linux. Here what we have when we try to run the test without the additional option:
```
alexandre@debian$ swift test
/home/alexandre/lab/vapor-app/Tests/LinuxMain.swift:1:8: error: Run the tests with `swift test --enable-test-discovery`.
#error("Run the tests with `swift test --enable-test-discovery`.")
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```