### PR TITLE
Pull from vapor/swift:latest, which now exists

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ================================
 # Build image
 # ================================
-FROM vapor/swift:5.2 as build
+FROM vapor/swift:latest as build
 WORKDIR /build{{#fluent.db.is_sqlite}}
 
 # Install sqlite3


### PR DESCRIPTION
This way the Dockerfile doesn't have to keep getting updated for each point release. It can be put back to a hardcoded version on a case-by-case basis if a release breaks things.