### PR TITLE
Fix copy from location for Public directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ WORKDIR /staging
 RUN cp "$(swift build --package-path /build -c release --show-bin-path)/Run" ./
 
 # Uncomment the next line if you need to load resources from the `Public` directory.
-#RUN mv Public /staging/Public
+#RUN mv /build/Public /staging/Public
 
 # ================================
 # Run image


### PR DESCRIPTION
Fixes an issue where uncommenting the line to copy over files in `Public` would fail as we've changed the working directory and `Public` is still in the original place