### PR TITLE
Don't leave the Public directory or its contents writable by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
     && apt-get install -y libsqlite3-dev {{/fluent.db.is_sqlite}}\
     && rm -rf /var/lib/apt/lists/*
 
+# Set up a build area
 WORKDIR /build
 
 # First just resolve dependencies.
@@ -22,7 +23,7 @@ RUN swift package resolve
 # Copy entire repo into container
 COPY . .
 
-# Compile with optimizations
+# Build everything, with optimizations and test discovery
 RUN swift build --enable-test-discovery -c release
 
 # Switch to the staging area
@@ -32,7 +33,8 @@ WORKDIR /staging
 RUN cp "$(swift build --package-path /build -c release --show-bin-path)/Run" ./
 
 # Uncomment the next line if you need to load resources from the `Public` directory.
-#RUN mv /build/Public /staging/Public
+# Ensure that by default, neither the directory nor any of its contents are writable.
+#RUN mv /build/Public ./Public && chmod -R a-w ./Public
 
 # ================================
 # Run image


### PR DESCRIPTION
There's no value to a writable `Public` directory or contents thereof, since changes will not persist. Thus we write-protect the files by default to increase the difficulty of leveraging any potential compromise in the Vapor service, especially the difficulty of defacing any hosted content.