### PR TITLE
Update AppTests.swift for Swift 5.3

### DIFF
--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -7,9 +7,9 @@ final class AppTests: XCTestCase {
         defer { app.shutdown() }
         try configure(app)
 
-        try app.test(.GET, "hello") { res in
+        try app.test(.GET, "hello", afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(res.body.string, "Hello, world!")
-        }
+        })
     }
 }


### PR DESCRIPTION
Building this file with Swift 5.3 generates the following warning:

`Backward matching of the unlabeled trailing closure is deprecated; label the argument with 'afterResponse' to suppress this warning`

This update suppresses the warning by passing the closure as an `afterResponse:` argument in `app.test`