### PR TITLE
`docker-compose up migrate` should be `docker-compose run migrate`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@
 #   Build images: docker-compose build
 #      Start app: docker-compose up app{{#fluent}}{{^db.is_sqlite}}
 # Start database: docker-compose up db
-# Run migrations: docker-compose up migrate{{/db.is_sqlite}}{{/fluent}}
+# Run migrations: docker-compose run migrate{{/db.is_sqlite}}{{/fluent}}
 #       Stop all: docker-compose down{{#fluent}}{{^db.is_sqlite}} (add -v to wipe db){{/db.is_sqlite}}{{/fluent}}
 #
 version: '3.7'{{#fluent}}{{^db.is_sqlite}}


### PR DESCRIPTION
The `deploy: replicas: 0` configuration for the `migrate` and `revert` "services" in `docker-compose.yml` prevents `docker-compose up` from working correctly with them as of at least the current version of Docker Compose, possibly longer. It is more correct in either event to use `docker-compose run` for these instead.