### PR TITLE
Use name_kebab in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ x-shared_environment: &shared_environment
 
 services:
   app:
-    image: {{name_lower_kabab}}:latest
+    image: {{name_kebab}}:latest
     build:
       context: .
     environment:
@@ -40,7 +40,7 @@ services:
     # user: '0' # uncomment to run as root for testing purposes even though Dockerfile defines 'vapor' user.
     command: ["serve", "--env", "production", "--hostname", "0.0.0.0", "--port", "8080"]{{#fluent}}
   migrate:
-    image: {{name_lower_kabab}}:latest
+    image: {{name_kebab}}:latest
     build:
       context: .
     environment:
@@ -51,7 +51,7 @@ services:
     deploy:
       replicas: 0
   revert:
-    image: {{name_lower_kabab}}:latest
+    image: {{name_kebab}}:latest
     build:
       context: .
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ x-shared_environment: &shared_environment
 
 services:
   app:
-    image: {{name}}:latest
+    image: {{name_lower_kabab}}:latest
     build:
       context: .
     environment:
@@ -40,7 +40,7 @@ services:
     # user: '0' # uncomment to run as root for testing purposes even though Dockerfile defines 'vapor' user.
     command: ["serve", "--env", "production", "--hostname", "0.0.0.0", "--port", "8080"]{{#fluent}}
   migrate:
-    image: {{name}}:latest
+    image: {{name_lower_kabab}}:latest
     build:
       context: .
     environment:
@@ -51,7 +51,7 @@ services:
     deploy:
       replicas: 0
   revert:
-    image: {{name}}:latest
+    image: {{name_lower_kabab}}:latest
     build:
       context: .
     environment:


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->

Fixes #29 by using `name_kebab` instead of `name` as requested in https://github.com/vapor/toolbox/pull/323 .

Dependent upon https://github.com/vapor/toolbox/pull/353