### PR TITLE
Set platform tag to docker-compose: linux/amd64

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ x-shared_environment: &shared_environment
 services:
   app:
     image: {{name_kebab}}:latest
+    platform: linux/amd64
     build:
       context: .
     environment:


### PR DESCRIPTION
Added a platform tag to the docker compose file.

The platform tag is necessary for M1-Macs to build a amd version of the image that can be deployed to servers.

