### PR TITLE
Fix for missing root certificate store in base Ubuntu image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,8 @@ FROM ubuntu:focal
 
 # Make sure all system packages are up to date.
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && \
-    apt-get -q update && apt-get -q dist-upgrade -y && rm -r /var/lib/apt/lists/*
+    apt-get -q update && apt-get -q dist-upgrade -y && apt-get -q install -y ca-certificates && \
+    rm -r /var/lib/apt/lists/*
 
 # Create a vapor user and group with /app as its home directory
 RUN useradd --user-group --create-home --system --skel /dev/null --home-dir /app vapor


### PR DESCRIPTION
The base Ubuntu Docker images do not come with the root CA store installed, breaking anything using TLS. Install them in the runner image explicitly.