### PR TITLE
Fix bug where public directory is not added when using the template

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -81,6 +81,9 @@ files:
       - folder: Views
         files:
           - file: index.leaf
+  - folder: Public
+    files:
+      - .gitkeep
   - file: Dockerfile
     dynamic: true
   - file: docker-compose.yml


### PR DESCRIPTION
This fix consists of adding the folder to the manifest.yml file.

This should fix the problem of generating a new vapor project with the template and having no public folder generated.

closes #60 