### PR TITLE
Adding .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ DerivedData/
 .DS_Store
 db.sqlite
 .swiftpm
-
+.env


### PR DESCRIPTION
Adding .env to .gitignore to prevent accidental pushing of .env file to a public repo.