### PR TITLE
Install tzdata in the final Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ FROM ubuntu:focal
 
 # Make sure all system packages are up to date.
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && \
-    apt-get -q update && apt-get -q dist-upgrade -y && apt-get -q install -y ca-certificates && \
+    apt-get -q update && apt-get -q dist-upgrade -y && apt-get -q install -y ca-certificates tzdata && \
     rm -r /var/lib/apt/lists/*
 
 # Create a vapor user and group with /app as its home directory


### PR DESCRIPTION
Without the tzdata package installed, any Foundation call that involves Date formatting (most notably, ISO8601DateFormatter that is heavily relied upon by Vapor) will crash the application process with a SIGABRT.