### PR TITLE
Bump default Swift Docker image version to 5.6. Bump Swift tools version to 5.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ================================
 # Build image
 # ================================
-FROM swift:5.5-focal as build
+FROM swift:5.6-focal as build
 
 # Install OS updates and, if needed, sqlite3
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.6
 import PackageDescription
 
 let package = Package(

--- a/README.md
+++ b/README.md
@@ -18,6 +18,6 @@
         <img src="http://img.shields.io/badge/swift-5.2-brightgreen.svg" alt="Swift 5.2">
     </a>
     <a href="https://swift.org">
-        <img src="http://img.shields.io/badge/swift-5.5-brightgreen.svg" alt="Swift 5.5">
+        <img src="http://img.shields.io/badge/swift-5.5-brightgreen.svg" alt="Swift 5.6">
     </a>
 </p>


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

At the moment if you create a `vapor new` project it wont build for ARM without bumping the Dockerfile to `5.6` so I've gone ahead and bumped the defaults so hopefully this'll mitigate any confusion from end users.

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
