### PR TITLE
Return `204 (No Content)` instead of `200 (OK)` in `TodoController.delete`

### DIFF
--- a/Sources/App/Controllers/TodoController.swift
+++ b/Sources/App/Controllers/TodoController.swift
@@ -26,6 +26,6 @@ struct TodoController: RouteCollection {
             throw Abort(.notFound)
         }
         try await todo.delete(on: req.db)
-        return .ok
+        return .noContent
     }
 }


### PR DESCRIPTION
I feel like `204 (No Content)` is the best default for the `TodoController`'s `DELETE` response, given that the controller is also returning an empty response body by default.

AFAIK, there aren’t any _strict_ rules as to whether it should be `200` or `204`, but comparing the [documentation for each](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/DELETE#responses)  would suggest that `204` is more salient choice.

<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
