### PR TITLE
Fix crashes due to Dockerfile missing Swift runtime deps 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,9 +46,16 @@ RUN [ -d /build/Resources ] && { mv /build/Resources ./Resources && chmod -R a-w
 FROM ubuntu:focal
 
 # Make sure all system packages are up to date.
-RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && \
-    apt-get -q update && apt-get -q dist-upgrade -y && apt-get -q install -y ca-certificates tzdata{{#fluent.db.is_sqlite}} sqlite3{{/fluent.db.is_sqlite}} && \
-    rm -r /var/lib/apt/lists/*
+RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
+    && apt-get -q update \
+    && apt-get -q dist-upgrade -y \
+    && apt-get -q install -y \
+      ca-certificates \
+      libcurl4 \
+      libxml2{{#fluent.db.is_sqlite}} \
+      sqlite3{{/fluent.db.is_sqlite}} \
+      tzdata \
+    && rm -r /var/lib/apt/lists/*
 
 # Create a vapor user and group with /app as its home directory
 RUN useradd --user-group --create-home --system --skel /dev/null --home-dir /app vapor


### PR DESCRIPTION
The Swift runtime dynamically loads `libcurl4` and `libxml2` for
`FoundationNetworking` and `FoundationXML`, respectively -- the
`--static-swift-stdlib` build option can't include those libraries in
the binary so the runtime will crash at load.

For further reference:

* Deps in the official Swift "slim" image:
  https://github.com/apple/swift-docker/blob/a34976e/5.6/ubuntu/20.04/slim/Dockerfile#L5

* Swift on Server: Packaging Applications for Deployment:
  https://github.com/swift-server/guides/blob/main/docs/packaging.md

<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
