### PR TITLE
Add commented Swift deps to Dockerfile to ease opt-in (resolves #86)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,10 +45,19 @@ RUN [ -d /build/Resources ] && { mv /build/Resources ./Resources && chmod -R a-w
 # ================================
 FROM ubuntu:focal
 
-# Make sure all system packages are up to date.
-RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && \
-    apt-get -q update && apt-get -q dist-upgrade -y && apt-get -q install -y ca-certificates tzdata{{#fluent.db.is_sqlite}} sqlite3{{/fluent.db.is_sqlite}} && \
-    rm -r /var/lib/apt/lists/*
+# Make sure all system packages are up to date, and install only essential packages.
+RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
+    && apt-get -q update \
+    && apt-get -q dist-upgrade -y \
+    && apt-get -q install -y \
+      ca-certificates \
+      tzdata{{#fluent.db.is_sqlite}} \
+      sqlite3{{/fluent.db.is_sqlite}} \
+# If your app or its dependencies import FoundationNetworking, also install `libcurl4`.
+      # libcurl4 \
+# If your app or its dependencies import FoundationXML, also install `libxml2`.
+      # libxml2 \
+    && rm -r /var/lib/apt/lists/*
 
 # Create a vapor user and group with /app as its home directory
 RUN useradd --user-group --create-home --system --skel /dev/null --home-dir /app vapor


### PR DESCRIPTION
Most apps can run without `libcurl4` and `libxml2`, and omitting them makes the run image significantly smaller. When they are needed, this PR makes installing them easier. It also helps draw attention to the fact that they have been omitted.