### PR TITLE
Minor: Fix typo in commented name of bare template repo

### DIFF
--- a/.github/workflows/auto-template-creation.yml
+++ b/.github/workflows/auto-template-creation.yml
@@ -6,7 +6,7 @@
 # - https://github.com/vapor/template-fluent-postgres.git
 # - https://github.com/vapor/template-fluent-mysql.git
 # - https://github.com/vapor/template-fluent-postgres-leaf.git
-# - https://github.com/vapor/template-fluent-bare.git
+# - https://github.com/vapor/template-bare.git
 
 name: Create templates
 on:


### PR DESCRIPTION
Very minor comment typo I noticed (while exploring why no SQLite template repo is being autogenerated).