### PR TITLE
Modernize for Swift 5.8

### DIFF
--- a/.github/workflows/auto-template-creation.yml
+++ b/.github/workflows/auto-template-creation.yml
@@ -42,7 +42,7 @@ jobs:
             leafflag: --leaf
             repository: fluent-postgres-leaf
     runs-on: ubuntu-latest
-    container: "swift:5.5-focal"
+    container: "swift:5.8-jammy"
     steps:
       - name: Configure git
         run: |

--- a/.github/workflows/auto-template-creation.yml
+++ b/.github/workflows/auto-template-creation.yml
@@ -9,6 +9,9 @@
 # - https://github.com/vapor/template-bare.git
 
 name: Create templates
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 on:
   push:
     branches:
@@ -38,7 +41,6 @@ jobs:
           - fluentflag: --fluent.db postgres
             leafflag: --leaf
             repository: fluent-postgres-leaf
-
     runs-on: ubuntu-latest
     container: "swift:5.5-focal"
     steps:
@@ -46,13 +48,11 @@ jobs:
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Check out toolbox
-        uses: actions/checkout@v3.0.1
+        uses: actions/checkout@v3
         with:
           repository: vapor/toolbox
       - name: Build toolbox
-        run: swift build --enable-test-discovery -c debug
-
-
+        run: swift build
       - name: Generate template
         run: |
           git clone https://github.com/vapor/template-${{ matrix.repository }}.git

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   # Build the toolbox, then run vapor new and build the docker container for all options
   test-new:
-    #if: ${{ !github.event.pull_request.draft }}
+    if: ${{ !github.event.pull_request.draft }}
     strategy:
       fail-fast: false
       matrix:
@@ -33,7 +33,7 @@ jobs:
           swift run --package-path toolbox \
             vapor new template-test \
               --template ${{ github.event.pull_request.head.repo.clone_url }} \
-              --branch ${{ github.head_ref }}
+              --branch ${{ github.head_ref }} \
               --no-commit -o template-test \
               ${{ matrix.fluentflags }} ${{ matrix.leafflags }}
       - name: Build and test template

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -30,13 +30,13 @@ jobs:
           path: toolbox
       - name: Generate a project from the template
         run: |
-          swift --package-path toolbox run \
+          swift run --package-path toolbox \
             vapor new template-test \
               --template ${{ github.event.pull_request.head.repo.clone_url }} \
               --branch ${{ github.head_ref }}
               --no-commit -o template-test \
               ${{ matrix.fluentflags }} ${{ matrix.leafflags }}
       - name: Build and test template
-        run: swift --package-path template-test test
+        run: swift test --package-path template-test
       - name: Build Docker container
         run: docker compose --project-directory template-test build

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   # Build the toolbox, then run vapor new and build the docker container for all options
   test-new:
-    if: ${{ !github.event.pull_request.draft }}
+    #if: ${{ !github.event.pull_request.draft }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -1,65 +1,42 @@
-name: test 
-
-on: [pull_request]
-
-# Build the toolbox
-# Run vapor new for all options
-# Build the docker container
+name: test
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+on:
+  pull_request: { types: [opened, reopened, synchronize, ready_for_review] }
 
 jobs:
+  # Build the toolbox, then run vapor new and build the docker container for all options
   test-new:
+    if: ${{ !github.event.pull_request.draft }}
     strategy:
       fail-fast: false
       matrix:
         fluentflags:
-          - --no-fluent
-          - --fluent.db mysql
-          - --fluent.db postgres
-          - --fluent.db sqlite
-          - --fluent.db mongo
+          - '--no-fluent'
+          - '--fluent.db mysql'
+          - '--fluent.db postgres'
+          - '--fluent.db sqlite'
+          - '--fluent.db mongo'
         leafflags:
-          - --leaf
-          - --no-leaf
-        os: [ubuntu-20.04]
-    runs-on: ${{ matrix.os }}
-
+          - '--leaf'
+          - '--no-leaf'
+    runs-on: ubuntu-latest
     steps:
-          
-      - name: Extract source of pull request 
-        run:  |
-          echo "##[set-output name=source;]$(echo ${{ github.event.pull_request.head.repo.full_name }})"
-          echo "##[set-output name=branch;]$(echo ${{ github.head_ref }})"
-          echo "##[set-output name=fork;]$(echo ${{ github.server_url }}/${{ github.event.pull_request.head.repo.full_name }})"
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-        id: extract_source
-
       - name: Checkout the toolbox
-        uses: actions/checkout@v3.0.1
+        uses: actions/checkout@v3
         with:
           repository: vapor/toolbox
-
-      - name: Build the template from fork and  test it
-        if: ${{ steps.extract_source.outputs.source != 'vapor/template' }}
+          path: toolbox
+      - name: Generate a project from the template
         run: |
-          sudo swift run \
+          swift --package-path toolbox run \
             vapor new template-test \
-              --template ${{ steps.extract_source.outputs.fork }} \
-              --no-commit -o /template-test \
+              --template ${{ github.event.pull_request.head.repo.clone_url }} \
+              --branch ${{ github.head_ref }}
+              --no-commit -o template-test \
               ${{ matrix.fluentflags }} ${{ matrix.leafflags }}
-          sudo chown -R runner /template-test
-          cd /template-test
-          swift test
-          docker-compose build
-
-      - name: Build the template from branch and test it
-        if: ${{ steps.extract_source.outputs.source == 'vapor/template' }}
-        run: |
-          sudo swift run \
-            vapor new template-test \
-              --branch ${{ steps.extract_source.outputs.branch }} \
-              --no-commit -o /template-test \
-              ${{ matrix.fluentflags }} ${{ matrix.leafflags }}
-          sudo chown -R runner /template-test
-          cd /template-test
-          swift test
-          docker-compose build
+      - name: Build and test template
+        run: swift --package-path template-test test
+      - name: Build Docker container
+        run: docker compose --project-directory template-test build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,5 +9,6 @@ Thanks!
 ## Maintainers
 
 - [@0xTim](https://github.com/0xTim)
+- [@gwynne](https://github.com/gwynne)
 
 See the [Vapor maintainers doc](https://github.com/vapor/vapor/blob/main/Docs/maintainers.md) for more information.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ================================
 # Build image
 # ================================
-FROM swift:5.7-jammy as build
+FROM swift:5.8-jammy as build
 
 # Install OS updates and, if needed, sqlite3
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN swift build -c release --static-swift-stdlib
 WORKDIR /staging
 
 # Copy main executable to staging area
-RUN cp "$(swift build --package-path /build -c release --show-bin-path)/Run" ./
+RUN cp "$(swift build --package-path /build -c release --show-bin-path)/App" ./
 
 # Copy resources bundled by SPM to staging area
 RUN find -L "$(swift build --package-path /build -c release --show-bin-path)/" -regex '.*\.resources$' -exec cp -Ra {} ./ \;
@@ -73,5 +73,5 @@ USER vapor:vapor
 EXPOSE 8080
 
 # Start the Vapor service when the image is run, default to listening on 8080 in production environment
-ENTRYPOINT ["./Run"]
+ENTRYPOINT ["./App"]
 CMD ["serve", "--env", "production", "--hostname", "0.0.0.0", "--port", "8080"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Qutheory, LLC
+Copyright (c) 2023 Qutheory, LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.8
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/leaf.git", from: "4.0.0"),{{/leaf}}
     ],
     targets: [
-        .target(
+        .executableTarget(
             name: "App",
             dependencies: [{{#fluent}}
                 .product(name: "Fluent", package: "fluent"),
@@ -29,7 +29,6 @@ let package = Package(
                 .unsafeFlags(["-cross-module-optimization"], .when(configuration: .release))
             ]
         ),
-        .executableTarget(name: "Run", dependencies: [.target(name: "App")]),
         .testTarget(name: "AppTests", dependencies: [
             .target(name: "App"),
             .product(name: "XCTVapor", package: "vapor"),

--- a/Package.swift
+++ b/Package.swift
@@ -8,8 +8,8 @@ let package = Package(
     ],
     dependencies: [
         // 💧 A server-side Swift web framework.
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),{{#fluent}}
-        .package(url: "https://github.com/vapor/fluent.git", from: "4.0.0"),
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.76.0"),{{#fluent}}
+        .package(url: "https://github.com/vapor/fluent.git", from: "4.8.0"),
         .package(url: "https://github.com/vapor/fluent-{{fluent.db.url}}-driver.git", from: "{{fluent.db.version}}"),{{/fluent}}{{#leaf}}
         .package(url: "https://github.com/vapor/leaf.git", from: "4.0.0"),{{/leaf}}
     ],
@@ -25,7 +25,7 @@ let package = Package(
             swiftSettings: [
                 // Enable better optimizations when building in Release configuration. Despite the use of
                 // the `.unsafeFlags` construct required by SwiftPM, this flag is recommended for Release
-                // builds. See <https://github.com/swift-server/guides/blob/main/docs/building.md#building-for-production> for details.
+                // builds. See <https://www.swift.org/server/guides/building.html#building-for-production> for details.
                 .unsafeFlags(["-cross-module-optimization"], .when(configuration: .release))
             ]
         ),

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@
         <img src="https://github.com/vapor/vapor/workflows/test/badge.svg" alt="Continuous Integration">
     </a>
     <a href="https://swift.org">
-        <img src="http://img.shields.io/badge/swift-5.2-brightgreen.svg" alt="Swift 5.2">
+        <img src="http://img.shields.io/badge/swift-5.6-brightgreen.svg" alt="Swift 5.6">
     </a>
     <a href="https://swift.org">
-        <img src="http://img.shields.io/badge/swift-5.5-brightgreen.svg" alt="Swift 5.6">
+        <img src="http://img.shields.io/badge/swift-5.8-brightgreen.svg" alt="Swift 5.8">
     </a>
 </p>

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -4,7 +4,7 @@ import Fluent{{fluent.db.module}}Driver
 {{/leaf}}import Vapor
 
 // configures your application
-public func configure(_ app: Application) throws {
+public func configure(_ app: Application) async throws {
     // uncomment to serve files from /Public folder
     // app.middleware.use(FileMiddleware(publicDirectory: app.directory.publicDirectory)){{#fluent}}
 

--- a/Sources/App/entrypoint.swift
+++ b/Sources/App/entrypoint.swift
@@ -1,15 +1,35 @@
 import Vapor
+import Dispatch
+import Logging
+
+/// This extension is temporary and can be removed once Vapor gets this support.
+private extension Vapor.Application {
+    static let baseExecutionQueue = DispatchQueue(label: "vapor.codes.entrypoint")
+    
+    func runFromAsyncMainEntrypoint() async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            Vapor.Application.baseExecutionQueue.async { [self] in
+                do {
+                    try self.run()
+                    continuation.resume()
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+}
 
 @main
 enum Entrypoint {
-    static func main() throws {
+    static func main() async throws {
         var env = try Environment.detect()
         try LoggingSystem.bootstrap(from: &env)
         
         let app = Application(env)
         defer { app.shutdown() }
         
-        try configure(app)
-        try app.run()
+        try await configure(app)
+        try await app.runFromAsyncMainEntrypoint()
     }
 }

--- a/Sources/App/entrypoint.swift
+++ b/Sources/App/entrypoint.swift
@@ -1,0 +1,15 @@
+import Vapor
+
+@main
+enum Entrypoint {
+    static func main() throws {
+        var env = try Environment.detect()
+        try LoggingSystem.bootstrap(from: &env)
+        
+        let app = Application(env)
+        defer { app.shutdown() }
+        
+        try configure(app)
+        try app.run()
+    }
+}

--- a/Sources/Run/main.swift
+++ b/Sources/Run/main.swift
@@ -1,9 +1,0 @@
-import App
-import Vapor
-
-var env = try Environment.detect()
-try LoggingSystem.bootstrap(from: &env)
-let app = Application(env)
-defer { app.shutdown() }
-try configure(app)
-try app.run()

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -2,10 +2,10 @@
 import XCTVapor
 
 final class AppTests: XCTestCase {
-    func testHelloWorld() throws {
+    func testHelloWorld() async throws {
         let app = Application(.testing)
         defer { app.shutdown() }
-        try configure(app)
+        try await configure(app)
 
         try app.test(.GET, "hello", afterResponse: { res in
             XCTAssertEqual(res.status, .ok)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,7 @@ services:
     deploy:
       replicas: 0{{#db.is_postgres}}
   db:
-    image: postgres:14-alpine
+    image: postgres:15-alpine
     volumes:
       - db_data:/var/lib/postgresql/data/pgdata
     environment:

--- a/manifest.yml
+++ b/manifest.yml
@@ -48,11 +48,9 @@ files:
     dynamic: true
   - folder: Sources
     files:
-      - folder: Run
-        files:
-          - main.swift
       - folder: App
         files:
+          - file: entrypoint.swift
           - file: configure.swift
             dynamic: true
           - file: routes.swift


### PR DESCRIPTION
Makes the following updates:

- Make Swift 5.8 the default for generated projects
- Remove the separate `Run` target, making `App` the executable.
- Switch to using an `@main` entrypoint.
- Fix vapor/vapor#2648 (shoutout to @vzsg, who did most of the work on this)
- Update `README.md`, `CONTRIBUTING.md`, and `LICENSE`
- Require some more current minimum dependency versions in template `Package.swift`
- Update PostgreSQL version in template `docker-compose.yml`
- Major CI cleanups

Subsumes #78.