### PR TITLE
Work around a massive compile time regression in FluentPostgresDriver

### DIFF
--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -9,7 +9,7 @@ public func configure(_ app: Application) async throws {
     // uncomment to serve files from /Public folder
     // app.middleware.use(FileMiddleware(publicDirectory: app.directory.publicDirectory)){{#fluent}}
 
-    {{#fluent.db.is_postgres}}app.databases.use(.postgres(configuration: .init(
+    {{#fluent.db.is_postgres}}app.databases.use(.postgres(configuration: SQLPostgresConfiguration(
         hostname: Environment.get("DATABASE_HOST") ?? "localhost",
         port: Environment.get("DATABASE_PORT").flatMap(Int.init(_:)) ?? SQLPostgresConfiguration.ianaPortNumber,
         username: Environment.get("DATABASE_USERNAME") ?? "vapor_username",


### PR DESCRIPTION
Due to an issue with how the old APIs in PostgresKit and FluentPostgresDriver were deprecated, we must specify `SQLPostgresConfiguration` explicitly when creating the PostgreSQL database configuration to avoid a 60,000% penalty (yes, really - from 0.1s to 60s) when compiling `configure.swift`