### PR TITLE
Report errors from `configure(_:)` through the app's logger before throwing

### DIFF
--- a/Sources/App/entrypoint.swift
+++ b/Sources/App/entrypoint.swift
@@ -29,7 +29,12 @@ enum Entrypoint {
         let app = Application(env)
         defer { app.shutdown() }
         
-        try await configure(app)
+        do {
+            try await configure(app)
+        } catch {
+            app.logger.report(error: error)
+            throw error
+        }
         try await app.runFromAsyncMainEntrypoint()
     }
 }


### PR DESCRIPTION
This ensures the full error details, which are not always reported by the "error raised at top level" handler in the runtime, are logged.