### PR TITLE
Fix Dockerfile when no Package.resolved is present

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /build
 # files do not change.
 COPY ./Package.* ./
 RUN swift package resolve --skip-update \
-        "$([ -f ./Package.resolved ] && echo "--force-resolved-versions" || true)"
+        $([ -f ./Package.resolved ] && echo "--force-resolved-versions" || true)
 
 # Copy entire repo into container
 COPY . .


### PR DESCRIPTION
When no `Package.resolved` was present, the `Dockerfile` would generate an invalid command. This is now fixed.

Fixes #110.