### PR TITLE
Async entrypoints and jemalloc

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    allow:
+      - dependency-type: all
     groups:
       dependencies:
         patterns:

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,8 @@ FROM swift:5.9-jammy as build
 # Install OS updates
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
     && apt-get -q update \
-    && apt-get -q dist-upgrade -y\
-    && apt-get install -y libjemalloc-dev\
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get -q dist-upgrade -y \
+    && apt-get install -y libjemalloc-dev
 
 # Set up a build area
 WORKDIR /build
@@ -25,7 +24,9 @@ RUN swift package resolve --skip-update \
 COPY . .
 
 # Build everything, with optimizations, with static linking, and using jemalloc
-RUN swift build -c release --static-swift-stdlib \
+# N.B.: The static version of jemalloc is incompatible with the static Swift runtime.
+RUN swift build -c release \
+                --static-swift-stdlib \
                 -Xlinker -ljemalloc
 
 # Switch to the staging area
@@ -55,6 +56,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
     && apt-get -q update \
     && apt-get -q dist-upgrade -y \
     && apt-get -q install -y \
+      libjemalloc2 \
       ca-certificates \
       tzdata \
 # If your app or its dependencies import FoundationNetworking, also install `libcurl4`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ FROM swift:5.9-jammy as build
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
     && apt-get -q update \
     && apt-get -q dist-upgrade -y\
+    && apt-get install -y libjemalloc-dev\
     && rm -rf /var/lib/apt/lists/*
 
 # Set up a build area
@@ -23,17 +24,18 @@ RUN swift package resolve --skip-update \
 # Copy entire repo into container
 COPY . .
 
-# Build everything, with optimizations
+# Build everything, with optimizations, with static linking, and using jemalloc
 RUN swift build -c release --static-swift-stdlib \
-    # Workaround for https://github.com/apple/swift/pull/68669
-    # This can be removed as soon as 5.9.1 is released, but is harmless if left in.
-    -Xlinker -u -Xlinker _swift_backtrace_isThunkFunction
+                -Xlinker -ljemalloc
 
 # Switch to the staging area
 WORKDIR /staging
 
 # Copy main executable to staging area
 RUN cp "$(swift build --package-path /build -c release --show-bin-path)/App" ./
+
+# Copy static swift backtracer binary to staging area
+RUN cp "/usr/libexec/swift/linux/swift-backtrace-static" ./
 
 # Copy resources bundled by SPM to staging area
 RUN find -L "$(swift build --package-path /build -c release --show-bin-path)/" -regex '.*\.resources$' -exec cp -Ra {} ./ \;
@@ -46,7 +48,7 @@ RUN [ -d /build/Resources ] && { mv /build/Resources ./Resources && chmod -R a-w
 # ================================
 # Run image
 # ================================
-FROM swift:5.9-jammy-slim
+FROM ubuntu:latest
 
 # Make sure all system packages are up to date, and install only essential packages.
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
@@ -71,7 +73,7 @@ WORKDIR /app
 COPY --from=build --chown=vapor:vapor /staging /app
 
 # Provide configuration needed by the built-in crash reporter and some sensible default behaviors.
-ENV SWIFT_ROOT=/usr SWIFT_BACKTRACE=enable=yes,sanitize=yes,threads=all,images=all,interactive=no
+ENV SWIFT_BACKTRACE=enable=yes,sanitize=yes,threads=all,images=all,interactive=no
 
 # Ensure all further commands run as the vapor user
 USER vapor:vapor

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     ],
     dependencies: [
         // 💧 A server-side Swift web framework.
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.83.1"),{{#fluent}}
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.89.0"),{{#fluent}}
         // 🗄 An ORM for SQL and NoSQL databases.
         .package(url: "https://github.com/vapor/fluent.git", from: "4.8.0"),
         // {{fluent.db.emoji}} Fluent driver for {{fluent.db.module}}.

--- a/Sources/App/entrypoint.swift
+++ b/Sources/App/entrypoint.swift
@@ -1,24 +1,5 @@
 import Vapor
-import Dispatch
 import Logging
-
-/// This extension is temporary and can be removed once Vapor gets this support.
-private extension Vapor.Application {
-    static let baseExecutionQueue = DispatchQueue(label: "vapor.codes.entrypoint")
-    
-    func runFromAsyncMainEntrypoint() async throws {
-        try await withCheckedThrowingContinuation { continuation in
-            Vapor.Application.baseExecutionQueue.async { [self] in
-                do {
-                    try self.run()
-                    continuation.resume()
-                } catch {
-                    continuation.resume(throwing: error)
-                }
-            }
-        }
-    }
-}
 
 @main
 enum Entrypoint {
@@ -35,6 +16,6 @@ enum Entrypoint {
             app.logger.report(error: error)
             throw error
         }
-        try await app.runFromAsyncMainEntrypoint()
+        try await app.execute()
     }
 }


### PR DESCRIPTION
Uses the new async entrypoints in Vapor, updates the backtracing logic for Swift 5.9.1, and switches to using libjemalloc by default in built images.

Supersedes #116 