### PR TITLE
Pin runner image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN [ -d /build/Resources ] && { mv /build/Resources ./Resources && chmod -R a-w
 # ================================
 # Run image
 # ================================
-FROM ubuntu:latest
+FROM ubuntu:jammy
 
 # Make sure all system packages are up to date, and install only essential packages.
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \


### PR DESCRIPTION
The template currently specifies `ubuntu:latest`, which can end up choosing a version of Ubuntu not officially supported by Swift. While this probably isn't critical given the use of statically linked executables, for full correctness we should pin to the newest supported version (Jammy at the time of this writing) instead.