### PR TITLE
Fix Dockerfile `unable to locate swift-backtrace`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ WORKDIR /app
 COPY --from=build --chown=vapor:vapor /staging /app
 
 # Provide configuration needed by the built-in crash reporter and some sensible default behaviors.
-ENV SWIFT_BACKTRACE=enable=yes,sanitize=yes,threads=all,images=all,interactive=no
+ENV SWIFT_BACKTRACE=enable=yes,sanitize=yes,threads=all,images=all,interactive=no,swift-backtrace=./swift-backtrace-static
 
 # Ensure all further commands run as the vapor user
 USER vapor:vapor


### PR DESCRIPTION
The error from Penny:

<kbd>
<img width="874" alt="Screenshot 2023-12-19 at 4 48 37 PM" src="https://github.com/vapor/template/assets/54685446/fb3d73bd-297a-4437-96d8-449875e9c669">
</kbd>   


This PR fixes that by providing the explicit path of the backtrace binary to Swift's runtime.
