### PR TITLE
fix: support swift strict concurrency checking

### DIFF
--- a/Sources/App/Controllers/TodoController.swift
+++ b/Sources/App/Controllers/TodoController.swift
@@ -11,16 +11,19 @@ struct TodoController: RouteCollection {
         }
     }
 
+    @Sendable
     func index(req: Request) async throws -> [Todo] {
         try await Todo.query(on: req.db).all()
     }
 
+    @Sendable
     func create(req: Request) async throws -> Todo {
         let todo = try req.content.decode(Todo.self)
         try await todo.save(on: req.db)
         return todo
     }
 
+    @Sendable
     func delete(req: Request) async throws -> HTTPStatus {
         guard let todo = try await Todo.find(req.parameters.get("todoID"), on: req.db) else {
             throw Abort(.notFound)


### PR DESCRIPTION
Adds support for compiling with [swift strict concurrency checking](https://www.swift.org/documentation/concurrency/) enabled by marking `TodoController` methods as `Sendable`. 

Strict concurrency checking can be enabled by adding the following to the `App` target in Package.swift:
```
swiftSettings: [
    .enableExperimentalFeature("StrictConcurrency")
]
```

Strict concurrency checking generates the following warnings:

<img width="1022" alt="Screenshot 2024-03-10 at 1 24 06 PM" src="https://github.com/vapor/template/assets/29186822/e443f966-4a2a-4369-ad83-2bf84196e013">

As of swift 5.10, these are warnings, but they may become errors in a future version.  Marking these functions as `Sendable` by adding the `@Sendable` annotation resolves this issue.
