### PR TITLE
Add leading spaces to routes.swift

### DIFF
--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -4,7 +4,7 @@
 func routes(_ app: Application) throws {
     {{#leaf}}app.get { req async throws in
         try await req.view.render("index", ["title": "Hello Vapor!"])
-    }{{/leaf}}{{^leaf}}app.get { req async in
+    }{{/leaf}}{{^leaf}}    app.get { req async in
         "It works!"
     }{{/leaf}}
 


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

Currently when creating a new project without leaf, leading spaces are missing in `./Sources/App/routes.swift`

```swift
func routes(_ app: Application) throws {
app.get { req async in
```

This PR adds the missing leading spaces to match expectation

```swift
func routes(_ app: Application) throws {
    app.get { req async in
```

Alternative considered modification was to move the mustache selection earlier, but caused `Error: Mustache error: bad unescape tag`, and was not able to find solution to resolve the issue.

```
func routes(_ app: Application) throws {{{#leaf}}
    app.get { req async throws in
        try await req.view.render("index", ["title": "Hello Vapor!"])
    }{{/leaf}}{{^leaf}}
    app.get { req async in
```

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
