### PR TITLE
Update for Swift 5.10 and strict concurrency

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -7,7 +7,7 @@ on:
       cache_key:
         value: ${{ jobs.cache-toolbox.outputs.cache_key }}
 env:
-  SWIFT_IMAGE: 'swift:5.9-jammy'
+  SWIFT_IMAGE: 'swift:5.10-jammy'
 
 jobs:
   

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ================================
 # Build image
 # ================================
-FROM swift:5.9-jammy as build
+FROM swift:5.10-jammy as build
 
 # Install OS updates
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \

--- a/Package.swift
+++ b/Package.swift
@@ -40,5 +40,5 @@ let package = Package(
 
 var swiftSettings: [SwiftSetting] { [
     .enableUpcomingFeature("DisableOutwardActorInference"),
-    .enableExperimentalFeature("StrictConcurrency=complete"),
+    .enableExperimentalFeature("StrictConcurrency"),
 ] }

--- a/Package.swift
+++ b/Package.swift
@@ -44,7 +44,7 @@ let package = Package(
     ]
 )
 
-var swiftSettings: [SwiftSetting] = [
+var swiftSettings: [SwiftSetting] { [
     .enableUpcomingFeature("DisableOutwardActorInference"),
-    .enableUpcomingFeature("StrictConcurrency"),
-]
+    .enableExperimentalFeature("StrictConcurrency=complete"),
+] }

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 import PackageDescription
 
 let package = Package(
@@ -8,13 +8,13 @@ let package = Package(
     ],
     dependencies: [
         // 💧 A server-side Swift web framework.
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.89.0"),{{#fluent}}
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.92.4"),{{#fluent}}
         // 🗄 An ORM for SQL and NoSQL databases.
-        .package(url: "https://github.com/vapor/fluent.git", from: "4.8.0"),
+        .package(url: "https://github.com/vapor/fluent.git", from: "4.9.0"),
         // {{fluent.db.emoji}} Fluent driver for {{fluent.db.module}}.
         .package(url: "https://github.com/vapor/fluent-{{fluent.db.url}}-driver.git", from: "{{fluent.db.version}}"),{{/fluent}}{{#leaf}}
         // 🍃 An expressive, performant, and extensible templating language built for Swift.
-        .package(url: "https://github.com/vapor/leaf.git", from: "4.2.4"),{{/leaf}}
+        .package(url: "https://github.com/vapor/leaf.git", from: "4.3.0"),{{/leaf}}
     ],
     targets: [
         .executableTarget(
@@ -24,17 +24,27 @@ let package = Package(
                 .product(name: "Fluent{{fluent.db.module}}Driver", package: "fluent-{{fluent.db.url}}-driver"),{{/fluent}}{{#leaf}}
                 .product(name: "Leaf", package: "leaf"),{{/leaf}}
                 .product(name: "Vapor", package: "vapor"),
-            ]
+            ],
+            swiftSettings: swiftSettings
         ),
-        .testTarget(name: "AppTests", dependencies: [
-            .target(name: "App"),
-            .product(name: "XCTVapor", package: "vapor"),
-
-            // Workaround for https://github.com/apple/swift-package-manager/issues/6940
-            .product(name: "Vapor", package: "vapor"),{{#fluent}}
-            .product(name: "Fluent", package: "Fluent"),
-            .product(name: "Fluent{{fluent.db.module}}Driver", package: "fluent-{{fluent.db.url}}-driver"),{{/fluent}}{{#leaf}}
-            .product(name: "Leaf", package: "leaf"),{{/leaf}}
-        ])
+        .testTarget(
+            name: "AppTests",
+            dependencies: [
+                .target(name: "App"),
+                .product(name: "XCTVapor", package: "vapor"),
+    
+                // Workaround for https://github.com/apple/swift-package-manager/issues/6940
+                .product(name: "Vapor", package: "vapor"),{{#fluent}}
+                .product(name: "Fluent", package: "Fluent"),
+                .product(name: "Fluent{{fluent.db.module}}Driver", package: "fluent-{{fluent.db.url}}-driver"),{{/fluent}}{{#leaf}}
+                .product(name: "Leaf", package: "leaf"),{{/leaf}}
+            ],
+            swiftSettings: swiftSettings
+        )
     ]
 )
+
+var swiftSettings: [SwiftSetting] = [
+    .enableUpcomingFeature("DisableOutwardActorInference"),
+    .enableUpcomingFeature("StrictConcurrency"),
+]

--- a/Package.swift
+++ b/Package.swift
@@ -32,12 +32,6 @@ let package = Package(
             dependencies: [
                 .target(name: "App"),
                 .product(name: "XCTVapor", package: "vapor"),
-    
-                // Workaround for https://github.com/apple/swift-package-manager/issues/6940
-                .product(name: "Vapor", package: "vapor"),{{#fluent}}
-                .product(name: "Fluent", package: "Fluent"),
-                .product(name: "Fluent{{fluent.db.module}}Driver", package: "fluent-{{fluent.db.url}}-driver"),{{/fluent}}{{#leaf}}
-                .product(name: "Leaf", package: "leaf"),{{/leaf}}
             ],
             swiftSettings: swiftSettings
         )

--- a/README.md
+++ b/README.md
@@ -2,19 +2,9 @@
     <img src="https://user-images.githubusercontent.com/1342803/36623515-7293b4ec-18d3-11e8-85ab-4e2f8fb38fbd.png" width="320" alt="Vapor Template">
     <br>
     <br>
-    <a href="http://docs.vapor.codes/4.0/">
-        <img src="http://img.shields.io/badge/read_the-docs-2196f3.svg" alt="Documentation">
-    </a>
-    <a href="https://discord.gg/vapor">
-        <img src="https://img.shields.io/discord/431917998102675485.svg" alt="Team Chat">
-    </a>
-    <a href="LICENSE">
-        <img src="http://img.shields.io/badge/license-MIT-brightgreen.svg" alt="MIT License">
-    </a>
-    <a href="https://github.com/vapor/templates/actions/workflows/test-template.yml">
-        <img src="https://github.com/vapor/template/actions/workflows/test-template.yml/badge.svg?event=push" alt="Continuous Integration">
-    </a>
-    <a href="https://swift.org">
-        <img src="http://img.shields.io/badge/swift-5.9-brightgreen.svg" alt="Swift 5.9">
-    </a>
+    <a href="https://docs.vapor.codes/4.0/"><img src="https://design.vapor.codes/images/readthedocs.svg" alt="Documentation"></a>
+    <a href="https://discord.gg/vapor"><img src="https://design.vapor.codes/images/discordchat.svg" alt="Team Chat"></a>
+    <a href="LICENSE"><img src="https://design.vapor.codes/images/mitlicense.svg" alt="MIT License"></a>
+    <a href="https://github.com/vapor/template/actions/workflows/test-template.yml"><img src="https://img.shields.io/github/actions/workflow/status/vapor/template/test-template.yml?event=push&style=plastic&logo=github&label=tests&logoColor=%23ccc" alt="Continuous Integration"></a>
+    <a href="https://swift.org"><img src="https://design.vapor.codes/images/swift510up.svg" alt="Swift 5.10+"></a>
 </p>

--- a/Sources/App/Controllers/TodoController.swift
+++ b/Sources/App/Controllers/TodoController.swift
@@ -4,27 +4,33 @@ import Vapor
 struct TodoController: RouteCollection {
     func boot(routes: RoutesBuilder) throws {
         let todos = routes.grouped("todos")
-        todos.get(use: index)
-        todos.post(use: create)
+
+        todos.get(use: self.index)
+        todos.post(use: self.create)
         todos.group(":todoID") { todo in
-            todo.delete(use: delete)
+            todo.delete(use: self.delete)
         }
     }
-
+    
+    @Sendable
     func index(req: Request) async throws -> [Todo] {
         try await Todo.query(on: req.db).all()
     }
 
+    @Sendable
     func create(req: Request) async throws -> Todo {
         let todo = try req.content.decode(Todo.self)
+
         try await todo.save(on: req.db)
         return todo
     }
 
+    @Sendable
     func delete(req: Request) async throws -> HTTPStatus {
         guard let todo = try await Todo.find(req.parameters.get("todoID"), on: req.db) else {
             throw Abort(.notFound)
         }
+
         try await todo.delete(on: req.db)
         return .noContent
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,7 @@ services:
     ports:
       - '5432:5432'{{/db.is_postgres}}{{#db.is_mysql}}
   db:
-    image: mysql:8.0
+    image: mysql:8
     volumes:
       - db_data:/var/lib/mysql
     environment:

--- a/manifest.yml
+++ b/manifest.yml
@@ -14,7 +14,7 @@ variables:
               module: Postgres
               url: postgres
               id: psql
-              version: "2.7.2"
+              version: "2.8.0"
               is_postgres: true
               emoji: "\U0001F418"
           - name: MySQL
@@ -23,7 +23,7 @@ variables:
               module: MySQL
               url: mysql
               id: mysql
-              version: "4.0.0"
+              version: "4.4.0"
               is_mysql: true
               emoji: "\U0001F42C"
           - name: SQLite
@@ -32,7 +32,7 @@ variables:
               module: SQLite
               url: sqlite
               id: sqlite
-              version: "4.0.0"
+              version: "4.6.0"
               is_sqlite: true
               emoji: "\U0001FAB6"
           - name: Mongo
@@ -41,7 +41,7 @@ variables:
               module: Mongo
               url: mongo
               id: mongo
-              version: "1.0.0"
+              version: "1.3.1"
               is_mongo: true
               emoji: "\U0001F331"
   - name: leaf


### PR DESCRIPTION
Updates the template for Swift 5.10
- Enables [strict concurrency checking](https://www.swift.org/documentation/concurrency/).
- Eliminates strict concurrency warnings.
- Removes the workaround for https://github.com/apple/swift-package-manager/issues/6940.  Confirmed this issue was fixed in swift 5.9.2.

This is an extension of work by @gwynne in #125.

