### PR TITLE
Use a data transfer object instead of direct model encoding/decoding

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -45,10 +45,82 @@ jobs:
           docker run --rm -v "$(pwd):/toolbox-build" -w /toolbox-build "${SWIFT_IMAGE}" bash -c \
             'swift build -c release --static-swift-stdlib --product vapor && mkdir toolbox && cp .build/release/vapor toolbox/vapor'
     
-  # Run vapor new and build the docker container for all combinations of options
+  # Run vapor new and test the template for all combinations of options
   # Only run for PRs, running on push to main would be redundant.
   # Use normal "only one of this workflow per branch at a time, cancel stale jobs" concurrency
-  test-new:
+  test-new-and-build:
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.draft }}
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ toJSON(matrix) }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        swift-image:
+          - 'swift:5.10-jammy'
+        fluentflags:
+          - '--no-fluent'
+          #- '--fluent.db mysql' # The MySQL image can't be configured usably via GH Actions at this time
+          - '--fluent.db postgres'
+          - '--fluent.db sqlite'
+          - '--fluent.db mongo'
+        leafflags:
+          - '--leaf'
+          - '--no-leaf'
+        include:
+          #- fluentflags: '--fluent.db mysql'
+          #  dbhostname: mysql
+          - fluentflags: '--fluent.db postgres'
+            dbhostname: psql
+          - fluentflags: '--fluent.db mongo'
+            dbhosturl: 'mongodb://mongo:27017/vapor_database'
+    runs-on: ubuntu-latest
+    container: ${{ matrix.swift-image }}
+    needs: cache-toolbox
+    services:
+      mongo: { image: 'mongo:latest' }
+      #mysql:
+      #  image: mysql:latest
+      #  env: { MYSQL_ALLOW_EMPTY_PASSWORD: 'true', MYSQL_USER: vapor_username, MYSQL_PASSWORD: vapor_password, MYSQL_DATABASE: vapor_database }
+      psql:
+        image: postgres:latest
+        env: { POSTGRES_USER: vapor_username, POSTGRES_DB: vapor_database, POSTGRES_PASSWORD: vapor_password,
+               POSTGRES_HOST_AUTH_METHOD: 'scram-sha-256', POSTGRES_INITDB_ARGS: '--auth-host=scram-sha-256' }
+    steps:
+      - name: Get cached toolbox
+        id: get-cache
+        uses: actions/cache/restore@v4
+        with:
+          key: ${{ needs.cache-toolbox.outputs.cache_key }}
+          path: toolbox
+          fail-on-cache-miss: false
+      - name: Build toolbox inside container if cache fails
+        if: ${{ steps.get-cache.cache_hit != 'true' }}
+        run: |
+          apt-get update && apt-get install -y curl jq
+          tag="$(curl -fsSL "https://api.github.com/repos/vapor/toolbox/releases/latest" | jq -r .tag_name)"
+          git clone https://github.com/vapor/toolbox.git -b "${tag}" toolbox
+          swift build --package-path toolbox -c debug --product vapor
+          cp toolbox/.build/debug/vapor toolbox/vapor
+      - name: Generate a project from the template
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          CLONE_URL: ${{ github.event.pull_request.head.repo.clone_url }}
+        run: |
+          toolbox/vapor new template-test \
+            --template "${CLONE_URL}" --branch "${HEAD_REF}" \
+            --no-commit -o template-test \
+            ${{ matrix.fluentflags }} ${{ matrix.leafflags }}
+      - name: Build and test template
+        run: swift test --package-path template-test
+        env:
+          DATABASE_HOST: ${{ matrix.dbhostname }}
+          DATABASE_URL: ${{ matrix.dbhosturl }}
+    
+  # Run vapor new and build the container with Docker Compose for all combinations of options
+  # Only run for PRs, running on push to main would be redundant.
+  # Use normal "only one of this workflow per branch at a time, cancel stale jobs" concurrency
+  test-new-and-container:
     if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.draft }}
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ toJSON(matrix) }}
@@ -65,8 +137,8 @@ jobs:
         leafflags:
           - '--leaf'
           - '--no-leaf'
-    runs-on: ubuntu-latest
     needs: cache-toolbox
+    runs-on: ubuntu-latest
     steps:
       - name: Get cached toolbox
         uses: actions/cache/restore@v4
@@ -83,8 +155,5 @@ jobs:
             --template "${CLONE_URL}" --branch "${HEAD_REF}" \
             --no-commit -o template-test \
             ${{ matrix.fluentflags }} ${{ matrix.leafflags }}
-      - name: Build and test template in container
-        run: |
-          docker run --rm -v "$(pwd)/template-test:/template-test" "${SWIFT_IMAGE}" bash -c 'swift test --package-path /template-test'
       - name: Build Docker container
         run: docker compose --project-directory template-test build

--- a/Sources/App/Controllers/TodoController.swift
+++ b/Sources/App/Controllers/TodoController.swift
@@ -13,14 +13,14 @@ struct TodoController: RouteCollection {
     }
         
     func index(req: Request) async throws -> [TodoDTO] {
-        try await Todo.query(on: req.db).all().map(\.dto)
+        try await Todo.query(on: req.db).all().map { $0.toDTO() }
     }
 
     func create(req: Request) async throws -> TodoDTO {
-        let todo = try req.content.decode(TodoDTO.self).model
+        let todo = try req.content.decode(TodoDTO.self).toModel()
 
         try await todo.save(on: req.db)
-        return todo.dto
+        return todo.toDTO()
     }
 
     func delete(req: Request) async throws -> HTTPStatus {

--- a/Sources/App/Controllers/TodoController.swift
+++ b/Sources/App/Controllers/TodoController.swift
@@ -11,16 +11,16 @@ struct TodoController: RouteCollection {
             todo.delete(use: { try await self.delete(req: $0) })
         }
     }
-    
-    func index(req: Request) async throws -> [Todo] {
-        try await Todo.query(on: req.db).all()
+        
+    func index(req: Request) async throws -> [TodoDTO] {
+        try await Todo.query(on: req.db).all().map(\.dto)
     }
 
-    func create(req: Request) async throws -> Todo {
-        let todo = try req.content.decode(Todo.self)
+    func create(req: Request) async throws -> TodoDTO {
+        let todo = try req.content.decode(TodoDTO.self).model
 
         try await todo.save(on: req.db)
-        return todo
+        return todo.dto
     }
 
     func delete(req: Request) async throws -> HTTPStatus {

--- a/Sources/App/DTOs/TodoDTO.swift
+++ b/Sources/App/DTOs/TodoDTO.swift
@@ -5,7 +5,7 @@ struct TodoDTO: Content {
     var id: UUID?
     var title: String?
     
-    var model: Todo {
+    func toModel() -> Todo {
         let model = Todo()
         
         model.id = self.id

--- a/Sources/App/DTOs/TodoDTO.swift
+++ b/Sources/App/DTOs/TodoDTO.swift
@@ -1,0 +1,17 @@
+import Fluent
+import Vapor
+
+struct TodoDTO: Content {
+    var id: UUID?
+    var title: String?
+    
+    var model: Todo {
+        let model = Todo()
+        
+        model.id = self.id
+        if let title = self.title {
+            model.title = title
+        }
+        return model
+    }
+}

--- a/Sources/App/Models/Todo.swift
+++ b/Sources/App/Models/Todo.swift
@@ -19,7 +19,7 @@ final class Todo: Model, @unchecked Sendable {
         self.title = title
     }
     
-    var dto: TodoDTO {
+    func toDTO() -> TodoDTO {
         .init(
             id: self.id,
             title: self.$title.value

--- a/Sources/App/Models/Todo.swift
+++ b/Sources/App/Models/Todo.swift
@@ -1,10 +1,9 @@
 import Fluent
-import Vapor
 
 /// Property wrappers interact poorly with `Sendable` checking, causing a warning for the `@ID` property
 /// It is recommended you write your model with sendability checking on and then suppress the warning
 /// afterwards with `@unchecked Sendable`.
-final class Todo: Model, Content, @unchecked Sendable {
+final class Todo: Model, @unchecked Sendable {
     static let schema = "todos"
     
     @ID(key: .id)
@@ -18,5 +17,12 @@ final class Todo: Model, Content, @unchecked Sendable {
     init(id: UUID? = nil, title: String) {
         self.id = id
         self.title = title
+    }
+    
+    var dto: TodoDTO {
+        .init(
+            id: self.id,
+            title: self.$title.value
+        )
     }
 }

--- a/Sources/App/Models/Todo.swift
+++ b/Sources/App/Models/Todo.swift
@@ -1,4 +1,5 @@
 import Fluent
+import struct Foundation.UUID
 
 /// Property wrappers interact poorly with `Sendable` checking, causing a warning for the `@ID` property
 /// It is recommended you write your model with sendability checking on and then suppress the warning

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -33,7 +33,7 @@ final class AppTests: XCTestCase {
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(
                 try res.content.decode([TodoDTO].self).sorted(by: { $0.title ?? "" < $1.title ?? "" }),
-                sampleTodos.map(\.dto).sorted(by: { $0.title ?? "" < $1.title ?? "" })
+                sampleTodos.map { $0.toDTO() }.sorted(by: { $0.title ?? "" < $1.title ?? "" })
             )
         })
     }
@@ -46,7 +46,7 @@ final class AppTests: XCTestCase {
         }, afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
             let models = try await Todo.query(on: self.app.db).all()
-            XCTAssertEqual(models.map(\.dto.title), [newDTO.title])
+            XCTAssertEqual(models.map { $0.toDTO().title }, [newDTO.title])
         })
     }
     

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -2,14 +2,58 @@
 import XCTVapor
 
 final class AppTests: XCTestCase {
-    func testHelloWorld() async throws {
-        let app = Application(.testing)
-        defer { app.shutdown() }
+    let app: Application!
+    
+    override func setUp() async throws {
+        self.app = Application(.testing)
         try await configure(app)
-
-        try app.test(.GET, "hello", afterResponse: { res in
+    }
+    
+    override func tearDown() async throws {
+        self.app.shutdown()
+        self.app = nil
+    }
+    
+    func testHelloWorld() async throws {
+        try self.app.test(.GET, "hello", afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(res.body.string, "Hello, world!")
+        })
+    }
+    
+    func testTodoIndex() async throws {
+        let sampleTodos = [Todo(title: "sample1"), Todo(title: "sample2")]
+        try await sampleTodos.create(on: self.app.db)
+        
+        try self.app.test(.GET, "todos", afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(
+                try res.content.decode([TodoDTO].self).sorted(by: \.title),
+                sampleTodos.map(\.dto).sorted(by: \.title)
+            )
+        })
+    }
+    
+    func testTodoCreate() async throws {
+        let newDTO = TodoDTO(id: nil, title: "test")
+        
+        try self.app.test(.POST, "todos", beforeRequest: { req in
+            try req.content.encode(newDTO)
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+            let models = try await Todo.query(on: self.app.db).all()
+            XCTAssertEqual(models.map(\.dto), [newDTO])
+        })
+    }
+    
+    func testTodoDelete() async throws {
+        let testTodos = [Todo(title: "test1"), Todo(title: "test2")]
+        try await testTodos.create(on: app.db)
+        
+        try self.app.test(.DELETE, "todos/\(testTodos[0].id)", afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+            let model = try await Todo.find(testTodos[0].id, on: self.app.db)
+            XCTAssertNil(model)
         })
     }
 }

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -1,15 +1,19 @@
 @testable import App
 import XCTVapor
+{{#fluent}}import Fluent
+{{/fluent}}
 
 final class AppTests: XCTestCase {
-    let app: Application!
+    var app: Application!
     
     override func setUp() async throws {
         self.app = Application(.testing)
-        try await configure(app)
+        try await configure(app){{#fluent}}
+        try await app.autoMigrate(){{/fluent}}
     }
     
-    override func tearDown() async throws {
+    override func tearDown() async throws { {{#fluent}}
+        try await app.autoRevert(){{/fluent}}
         self.app.shutdown()
         self.app = nil
     }
@@ -19,7 +23,7 @@ final class AppTests: XCTestCase {
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(res.body.string, "Hello, world!")
         })
-    }
+    }{{#fluent}}
     
     func testTodoIndex() async throws {
         let sampleTodos = [Todo(title: "sample1"), Todo(title: "sample2")]
@@ -28,8 +32,8 @@ final class AppTests: XCTestCase {
         try self.app.test(.GET, "todos", afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(
-                try res.content.decode([TodoDTO].self).sorted(by: \.title),
-                sampleTodos.map(\.dto).sorted(by: \.title)
+                try res.content.decode([TodoDTO].self).sorted(by: { $0.title ?? "" < $1.title ?? "" }),
+                sampleTodos.map(\.dto).sorted(by: { $0.title ?? "" < $1.title ?? "" })
             )
         })
     }
@@ -37,12 +41,12 @@ final class AppTests: XCTestCase {
     func testTodoCreate() async throws {
         let newDTO = TodoDTO(id: nil, title: "test")
         
-        try self.app.test(.POST, "todos", beforeRequest: { req in
+        try await self.app.test(.POST, "todos", beforeRequest: { req in
             try req.content.encode(newDTO)
         }, afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
             let models = try await Todo.query(on: self.app.db).all()
-            XCTAssertEqual(models.map(\.dto), [newDTO])
+            XCTAssertEqual(models.map(\.dto.title), [newDTO.title])
         })
     }
     
@@ -50,10 +54,18 @@ final class AppTests: XCTestCase {
         let testTodos = [Todo(title: "test1"), Todo(title: "test2")]
         try await testTodos.create(on: app.db)
         
-        try self.app.test(.DELETE, "todos/\(testTodos[0].id)", afterResponse: { res in
-            XCTAssertEqual(res.status, .ok)
+        try await self.app.test(.DELETE, "todos/\(testTodos[0].requireID())", afterResponse: { res in
+            XCTAssertEqual(res.status, .noContent)
             let model = try await Todo.find(testTodos[0].id, on: self.app.db)
             XCTAssertNil(model)
         })
+    }{{/fluent}}
+}
+{{#fluent}}
+
+extension TodoDTO: Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.id == rhs.id && lhs.title == rhs.title
     }
 }
+{{/fluent}}

--- a/manifest.yml
+++ b/manifest.yml
@@ -63,6 +63,10 @@ files:
             if: fluent
             files:
               - Todo.swift
+          - folder: DTOs
+            if: fluent
+            files:
+              - TodoDTO.swift
           - folder: Migrations
             if: fluent
             files:
@@ -76,7 +80,8 @@ files:
     files:
       - folder: AppTests
         files:
-          - AppTests.swift
+          - file: AppTests.swift
+            dynamic: true
   - folder: Resources
     if: leaf
     files:


### PR DESCRIPTION
The current recommendation when working with Fluent models is to use DTOs (data transfer objects) when decoding requests and encoding responses, rather than conforming the models themselves to `Content` as has been done historically. Our template project should reflect that recommendation.

Also includes tests for the `TodoController` routes when Fluent is selected.