### PR TITLE
Add @unchecked Sendable to Todo

### DIFF
--- a/Sources/App/Models/Todo.swift
+++ b/Sources/App/Models/Todo.swift
@@ -1,7 +1,10 @@
 import Fluent
 import Vapor
 
-final class Todo: Model, Content {
+/// Property wrappers interact poorly with `Sendable` checking, causing a warning for the `@ID` property
+/// It is recommended you write your model with sendability checking on and then suppress the warning
+/// afterwards with `@unchecked Sendable`.
+final class Todo: Model, Content, @unchecked Sendable {
     static let schema = "todos"
     
     @ID(key: .id)


### PR DESCRIPTION
As per vapor/vapor#3180 and vapor/fluent-kit#601, the recent update to Fluent to add (nearly but not totally complete) `Sendable`-correctness results in a new warning of the form `Stored property '_id' of 'Sendable'-conforming class 'Todo' is mutable` for all types conforming to `Fields`, `Schema`, and/or `Model`. This adds the appropriate annotation to the template's `Todo` model for sample purposes.
(@gwynne  wrote this)
