### PR TITLE
Async Entry and Concurrency Executor Takeover

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,9 @@ let package = Package(
         // {{fluent.db.emoji}} Fluent driver for {{fluent.db.module}}.
         .package(url: "https://github.com/vapor/fluent-{{fluent.db.url}}-driver.git", from: "{{fluent.db.version}}"),{{/fluent}}{{#leaf}}
         // 🍃 An expressive, performant, and extensible templating language built for Swift.
-        .package(url: "https://github.com/vapor/leaf.git", from: "4.3.0"),{{/leaf}}
+        .package(url: "https://github.com/vapor/leaf.git", from: "4.3.0"),{{/leaf}},
+        // 🔵 Non-blocking, event-driven networking for Swift. Used for custom executors
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.65.0"),
     ],
     targets: [
         .executableTarget(
@@ -24,6 +26,8 @@ let package = Package(
                 .product(name: "Fluent{{fluent.db.module}}Driver", package: "fluent-{{fluent.db.url}}-driver"),{{/fluent}}{{#leaf}}
                 .product(name: "Leaf", package: "leaf"),{{/leaf}}
                 .product(name: "Vapor", package: "vapor"),
+                .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "NIOPosix", package: "swift-nio"),
             ],
             swiftSettings: swiftSettings
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     ],
     dependencies: [
         // 💧 A server-side Swift web framework.
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.99.0"),{{#fluent}}
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.99.3"),{{#fluent}}
         // 🗄 An ORM for SQL and NoSQL databases.
         .package(url: "https://github.com/vapor/fluent.git", from: "4.9.0"),
         // {{fluent.db.emoji}} Fluent driver for {{fluent.db.module}}.

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     ],
     dependencies: [
         // 💧 A server-side Swift web framework.
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.92.4"),{{#fluent}}
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.99.0"),{{#fluent}}
         // 🗄 An ORM for SQL and NoSQL databases.
         .package(url: "https://github.com/vapor/fluent.git", from: "4.9.0"),
         // {{fluent.db.emoji}} Fluent driver for {{fluent.db.module}}.

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         // {{fluent.db.emoji}} Fluent driver for {{fluent.db.module}}.
         .package(url: "https://github.com/vapor/fluent-{{fluent.db.url}}-driver.git", from: "{{fluent.db.version}}"),{{/fluent}}{{#leaf}}
         // 🍃 An expressive, performant, and extensible templating language built for Swift.
-        .package(url: "https://github.com/vapor/leaf.git", from: "4.3.0"),{{/leaf}},
+        .package(url: "https://github.com/vapor/leaf.git", from: "4.3.0"),{{/leaf}}
         // 🔵 Non-blocking, event-driven networking for Swift. Used for custom executors
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.65.0"),
     ],

--- a/Sources/App/entrypoint.swift
+++ b/Sources/App/entrypoint.swift
@@ -6,11 +6,15 @@ import NIOPosix
 @main
 enum Entrypoint {
     static func main() async throws {
-        _ = NIOSingletons.unsafeTryInstallSingletonPosixEventLoopGroupAsConcurrencyGlobalExecutor()
         var env = try Environment.detect()
         try LoggingSystem.bootstrap(from: &env)
         
         let app = try await Application.make(env)
+
+        let executorTakeoverSuccess = NIOSingletons.unsafeTryInstallSingletonPosixEventLoopGroupAsConcurrencyGlobalExecutor()
+        if !executorTakeoverSuccess {
+            app.logger.warning("Failed to install global NIO executor, using default")
+        }
         
         do {
             try await configure(app)

--- a/Sources/App/entrypoint.swift
+++ b/Sources/App/entrypoint.swift
@@ -1,9 +1,12 @@
 import Vapor
 import Logging
+import NIOCore
+import NIOPosix
 
 @main
 enum Entrypoint {
     static func main() async throws {
+        _ = NIOSingletons.unsafeTryInstallSingletonPosixEventLoopGroupAsConcurrencyGlobalExecutor()
         var env = try Environment.detect()
         try LoggingSystem.bootstrap(from: &env)
         

--- a/Sources/App/entrypoint.swift
+++ b/Sources/App/entrypoint.swift
@@ -11,10 +11,10 @@ enum Entrypoint {
         
         let app = try await Application.make(env)
 
+        // This attempts to install NIO as the Swift Concurrency global executor.
+        // You should not call any async functions before this point.
         let executorTakeoverSuccess = NIOSingletons.unsafeTryInstallSingletonPosixEventLoopGroupAsConcurrencyGlobalExecutor()
-        if !executorTakeoverSuccess {
-            app.logger.warning("Failed to install global NIO executor, using default")
-        }
+        app.logger.debug("Running with \(executorTakeoverSuccess ? "SwiftNIO" : "standard") Swift Concurrency default executor")
         
         do {
             try await configure(app)

--- a/Sources/App/entrypoint.swift
+++ b/Sources/App/entrypoint.swift
@@ -7,15 +7,16 @@ enum Entrypoint {
         var env = try Environment.detect()
         try LoggingSystem.bootstrap(from: &env)
         
-        let app = Application(env)
-        defer { app.shutdown() }
+        let app = try await Application.make(env)
         
         do {
             try await configure(app)
         } catch {
             app.logger.report(error: error)
+            try? await app.asyncShutdown()
             throw error
         }
         try await app.execute()
+        try await app.asyncShutdown()
     }
 }

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -7,19 +7,19 @@ final class AppTests: XCTestCase {
     var app: Application!
     
     override func setUp() async throws {
-        self.app = Application(.testing)
+        self.app = Application.make(.testing)
         try await configure(app){{#fluent}}
         try await app.autoMigrate(){{/fluent}}
     }
     
     override func tearDown() async throws { {{#fluent}}
         try await app.autoRevert(){{/fluent}}
-        self.app.shutdown()
+        try await self.app.asyncShutdown()
         self.app = nil
     }
     
     func testHelloWorld() async throws {
-        try self.app.test(.GET, "hello", afterResponse: { res in
+        try await self.app.test(.GET, "hello", afterResponse: { res async in
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(res.body.string, "Hello, world!")
         })
@@ -29,7 +29,7 @@ final class AppTests: XCTestCase {
         let sampleTodos = [Todo(title: "sample1"), Todo(title: "sample2")]
         try await sampleTodos.create(on: self.app.db)
         
-        try self.app.test(.GET, "todos", afterResponse: { res in
+        try await self.app.test(.GET, "todos", afterResponse: { res async in
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(
                 try res.content.decode([TodoDTO].self).sorted(by: { $0.title ?? "" < $1.title ?? "" }),
@@ -43,7 +43,7 @@ final class AppTests: XCTestCase {
         
         try await self.app.test(.POST, "todos", beforeRequest: { req in
             try req.content.encode(newDTO)
-        }, afterResponse: { res in
+        }, afterResponse: { res async in
             XCTAssertEqual(res.status, .ok)
             let models = try await Todo.query(on: self.app.db).all()
             XCTAssertEqual(models.map { $0.toDTO().title }, [newDTO.title])
@@ -54,7 +54,7 @@ final class AppTests: XCTestCase {
         let testTodos = [Todo(title: "test1"), Todo(title: "test2")]
         try await testTodos.create(on: app.db)
         
-        try await self.app.test(.DELETE, "todos/\(testTodos[0].requireID())", afterResponse: { res in
+        try await self.app.test(.DELETE, "todos/\(testTodos[0].requireID())", afterResponse: { res async in
             XCTAssertEqual(res.status, .noContent)
             let model = try await Todo.find(testTodos[0].id, on: self.app.db)
             XCTAssertNil(model)


### PR DESCRIPTION
Updates the template for the new async Application stuff and install NIO as a custom executor

Reliant on https://github.com/vapor/vapor/pull/3190 first