### PR TITLE
`Sendable` methods work in 5.10 and `swift package resolve --skip-update` is deprecated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /build
 # as long as your Package.swift/Package.resolved
 # files do not change.
 COPY ./Package.* ./
-RUN swift package resolve --skip-update \
+RUN swift package resolve \
         $([ -f ./Package.resolved ] && echo "--force-resolved-versions" || true)
 
 # Copy entire repo into container

--- a/Sources/App/Controllers/TodoController.swift
+++ b/Sources/App/Controllers/TodoController.swift
@@ -5,10 +5,10 @@ struct TodoController: RouteCollection {
     func boot(routes: RoutesBuilder) throws {
         let todos = routes.grouped("todos")
 
-        todos.get(self.index)
-        todos.post(self.create)
+        todos.get(use: self.index)
+        todos.post(use: self.create)
         todos.group(":todoID") { todo in
-            todo.delete(self.delete)
+            todo.delete(use: self.delete)
         }
     }
 

--- a/Sources/App/Controllers/TodoController.swift
+++ b/Sources/App/Controllers/TodoController.swift
@@ -5,17 +5,19 @@ struct TodoController: RouteCollection {
     func boot(routes: RoutesBuilder) throws {
         let todos = routes.grouped("todos")
 
-        todos.get(use: { try await self.index(req: $0) })
-        todos.post(use: { try await self.create(req: $0) })
+        todos.get(self.index)
+        todos.post(self.create)
         todos.group(":todoID") { todo in
-            todo.delete(use: { try await self.delete(req: $0) })
+            todo.delete(self.delete)
         }
     }
-        
+
+    @Sendable
     func index(req: Request) async throws -> [TodoDTO] {
         try await Todo.query(on: req.db).all().map { $0.toDTO() }
     }
 
+    @Sendable
     func create(req: Request) async throws -> TodoDTO {
         let todo = try req.content.decode(TodoDTO.self).toModel()
 
@@ -23,6 +25,7 @@ struct TodoController: RouteCollection {
         return todo.toDTO()
     }
 
+    @Sendable
     func delete(req: Request) async throws -> HTTPStatus {
         guard let todo = try await Todo.find(req.parameters.get("todoID"), on: req.db) else {
             throw Abort(.notFound)


### PR DESCRIPTION
Pretty much what the title says.