### PR TITLE
Run auto-template-creation workflow on 24.04

### DIFF
--- a/.github/workflows/auto-template-creation.yml
+++ b/.github/workflows/auto-template-creation.yml
@@ -43,7 +43,7 @@ jobs:
           # Postgres with Leaf repo
           - repository: template-fluent-postgres-leaf
             flags: --fluent.db postgres --leaf
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Get token
         id: get-token


### PR DESCRIPTION
The template generation workflow [failed](https://github.com/vapor/template/actions/runs/9484457729) after the last version bump, as the toolbox was built and cached on Ubuntu 24.04, while the generation WF was set to run on 22.04 - and glibc is not backwards compatible like that.