### PR TITLE
Disable NIO as the Concurrency Global Executor by default

### DIFF
--- a/Sources/App/entrypoint.swift
+++ b/Sources/App/entrypoint.swift
@@ -12,9 +12,11 @@ enum Entrypoint {
         let app = try await Application.make(env)
 
         // This attempts to install NIO as the Swift Concurrency global executor.
-        // You should not call any async functions before this point.
-        let executorTakeoverSuccess = NIOSingletons.unsafeTryInstallSingletonPosixEventLoopGroupAsConcurrencyGlobalExecutor()
-        app.logger.debug("Running with \(executorTakeoverSuccess ? "SwiftNIO" : "standard") Swift Concurrency default executor")
+        // You can enable it if you'd like to reduce the amount of context switching between NIO and Swift Concurrency.
+        // Note: this has caused issues with some libraries that use `.wait()` and cleanly shutting down.
+        // If enabled, you should be careful about calling async functions before this point as it can cause assertion failures.
+        // let executorTakeoverSuccess = NIOSingletons.unsafeTryInstallSingletonPosixEventLoopGroupAsConcurrencyGlobalExecutor()
+        // app.logger.debug("Running with \(executorTakeoverSuccess ? "SwiftNIO" : "standard") Swift Concurrency default executor")
         
         do {
             try await configure(app)

--- a/Sources/App/entrypoint.swift
+++ b/Sources/App/entrypoint.swift
@@ -16,7 +16,7 @@ enum Entrypoint {
         // Note: this has caused issues with some libraries that use `.wait()` and cleanly shutting down.
         // If enabled, you should be careful about calling async functions before this point as it can cause assertion failures.
         // let executorTakeoverSuccess = NIOSingletons.unsafeTryInstallSingletonPosixEventLoopGroupAsConcurrencyGlobalExecutor()
-        // app.logger.debug("Running with \(executorTakeoverSuccess ? "SwiftNIO" : "standard") Swift Concurrency default executor")
+        // app.logger.debug("Tried to install SwiftNIO's EventLoopGroup as Swift's global concurrency executor", metadata: ["success": .stringConvertible(executorTakeoverSuccess)])
         
         do {
             try await configure(app)


### PR DESCRIPTION
Has caused a few issues so disable by default.

Also clarity the comments