### PR TITLE
Use Ubuntu `jammy` instead of `noble` for now

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -7,10 +7,10 @@ on:
       cache_key:
         value: ${{ jobs.cache-toolbox.outputs.cache_key }}
 env:
-  SWIFT_IMAGE: 'swift:6.0-noble'
+  SWIFT_IMAGE: 'swift:6.0-jammy'
 
 jobs:
-  
+
   # Check if a build of most recent release of the toolbox for the runner's OS and arch is cached, build and cache it if not
   # Run for both PRs and pushes to main so every individual PR doesn't have to rebuild the toolbox at least once
   # Use a concurrency group with no cancellation to avoid redundant builds; queued jobs will see the cache when they get their turn
@@ -44,7 +44,7 @@ jobs:
         run: |
           docker run --rm -v "$(pwd):/toolbox-build" -w /toolbox-build "${SWIFT_IMAGE}" bash -c \
             'swift build -c release --static-swift-stdlib --product vapor && mkdir toolbox && cp .build/release/vapor toolbox/vapor'
-    
+
   # Run vapor new and test the template for all combinations of options
   # Only run for PRs, running on push to main would be redundant.
   # Use normal "only one of this workflow per branch at a time, cancel stale jobs" concurrency
@@ -57,7 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         swift-image:
-          - 'swift:6.0-noble'
+          - 'swift:6.0-jammy'
         fluentflags:
           - '--no-fluent'
           #- '--fluent.db mysql' # The MySQL image can't be configured usably via GH Actions at this time
@@ -116,7 +116,7 @@ jobs:
         env:
           DATABASE_HOST: ${{ matrix.dbhostname }}
           DATABASE_URL: ${{ matrix.dbhosturl }}
-    
+
   # Run vapor new and build the container with Docker Compose for all combinations of options
   # Only run for PRs, running on push to main would be redundant.
   # Use normal "only one of this workflow per branch at a time, cancel stale jobs" concurrency

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ================================
 # Build image
 # ================================
-FROM swift:6.0-noble AS build
+FROM swift:6.0-jammy AS build
 
 # Install OS updates
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
@@ -49,7 +49,7 @@ RUN [ -d /build/Resources ] && { mv /build/Resources ./Resources && chmod -R a-w
 # ================================
 # Run image
 # ================================
-FROM ubuntu:noble
+FROM ubuntu:jammy
 
 # Make sure all system packages are up to date, and install only essential packages.
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \


### PR DESCRIPTION
Swift 6 has had [significant build time regressions](https://github.com/swiftlang/swift/issues/76555) which hopefully will become less significant by Swift 6.0.3.
Regardless, even on Swift 5.10, Swift noble seems to have build time / memory-usage regressions.
We've also had reports of similar OOM problems by Heorku users on Discord.
Swift build times are already not good, and there is a chance of running out of memory which will be confusing to users.
Let's not risk it and just use Swift jammy for now.