### PR TITLE
Revert DB on the error path in tests

### DIFF
--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -12,7 +12,8 @@ struct AppTests {
         let app = try await Application.make(.testing)
         do {
             try await configure(app)
-            {{#fluent}}try await app.autoMigrate()   
+            {{#fluent}}try await app.autoRevert()
+            try await app.autoMigrate()
 {{/fluent}}            try await test(app)
             {{#fluent}}try await app.autoRevert()   
 {{/fluent}}        }

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -12,13 +12,13 @@ struct AppTests {
         let app = try await Application.make(.testing)
         do {
             try await configure(app)
-            {{#fluent}}try await app.autoRevert()
-            try await app.autoMigrate()
+            {{#fluent}}try await app.autoMigrate()
 {{/fluent}}            try await test(app)
             {{#fluent}}try await app.autoRevert()   
 {{/fluent}}        }
         catch {
-            try await app.asyncShutdown()
+            {{#fluent}}try? await app.autoRevert()
+{{/fluent}}            try await app.asyncShutdown()
             throw error
         }
         try await app.asyncShutdown()

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -12,7 +12,7 @@ struct AppTests {
         let app = try await Application.make(.testing)
         do {
             try await configure(app)
-            {{#fluent}}try await app.autoMigrate()
+            {{#fluent}}try await app.autoMigrate()   
 {{/fluent}}            try await test(app)
             {{#fluent}}try await app.autoRevert()   
 {{/fluent}}        }


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

If a test throws an error the database won't be reverted and on successive tests or runs the DB will not be clean.

We can avoid this by running `app.autoRevert()` before each migration (This is also done in the Kodeco book).

P.S. By doing this we may not need the revert after the test is run

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
