### PR TITLE
Use Ubuntu/Swift Noble Again

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -7,7 +7,7 @@ on:
       cache_key:
         value: ${{ jobs.cache-toolbox.outputs.cache_key }}
 env:
-  SWIFT_IMAGE: 'swift:6.0-jammy'
+  SWIFT_IMAGE: 'swift:6.0-noble'
 
 jobs:
 
@@ -57,7 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         swift-image:
-          - 'swift:6.0-jammy'
+          - 'swift:6.0-noble'
         fluentflags:
           - '--no-fluent'
           #- '--fluent.db mysql' # The MySQL image can't be configured usably via GH Actions at this time

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ================================
 # Build image
 # ================================
-FROM swift:6.0-jammy AS build
+FROM swift:6.0-noble AS build
 
 # Install OS updates
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
@@ -50,7 +50,7 @@ RUN [ -d /build/Resources ] && { mv /build/Resources ./Resources && chmod -R a-w
 # ================================
 # Run image
 # ================================
-FROM ubuntu:jammy
+FROM ubuntu:noble
 
 # Make sure all system packages are up to date, and install only essential packages.
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \


### PR DESCRIPTION
Was just testing stuff in Penny, and Swift 6.0.3 seems to have fixed most of the discrepancies / regressions.