### PR TITLE
Ensure the app is shut down if app.execute() throws

### DIFF
--- a/Sources/App/entrypoint.swift
+++ b/Sources/App/entrypoint.swift
@@ -20,12 +20,12 @@ enum Entrypoint {
         
         do {
             try await configure(app)
+            try await app.execute()
         } catch {
             app.logger.report(error: error)
             try? await app.asyncShutdown()
             throw error
         }
-        try await app.execute()
         try await app.asyncShutdown()
     }
 }


### PR DESCRIPTION
Previously, if `app.execute()` threw an error, we would fail to shut down the `Application`.