### PR TITLE
fix: exclude .env.example from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,5 @@ db.sqlite
 .swiftpm
 .env
 .env.*
-! .env.example
+!.env.example
 .vscode


### PR DESCRIPTION
Resolves #154 