### PR TITLE
Remove MongoDB

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -63,7 +63,6 @@ jobs:
           #- '--fluent.db mysql' # The MySQL image can't be configured usably via GH Actions at this time
           - '--fluent.db postgres'
           - '--fluent.db sqlite'
-          - '--fluent.db mongo'
         leafflags:
           - '--leaf'
           - '--no-leaf'
@@ -72,13 +71,10 @@ jobs:
           #  dbhostname: mysql
           - fluentflags: '--fluent.db postgres'
             dbhostname: psql
-          - fluentflags: '--fluent.db mongo'
-            dbhosturl: 'mongodb://mongo:27017/vapor_database'
     runs-on: ubuntu-latest
     container: ${{ matrix.swift-image }}
     needs: cache-toolbox
     services:
-      mongo: { image: 'mongo:latest' }
       #mysql:
       #  image: mysql:latest
       #  env: { MYSQL_ALLOW_EMPTY_PASSWORD: 'true', MYSQL_USER: vapor_username, MYSQL_PASSWORD: vapor_password, MYSQL_DATABASE: vapor_database }
@@ -133,7 +129,6 @@ jobs:
           - '--fluent.db mysql'
           - '--fluent.db postgres'
           - '--fluent.db sqlite'
-          - '--fluent.db mongo'
         leafflags:
           - '--leaf'
           - '--no-leaf'

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -22,9 +22,7 @@ public func configure(_ app: Application) async throws {
         username: Environment.get("DATABASE_USERNAME") ?? "vapor_username",
         password: Environment.get("DATABASE_PASSWORD") ?? "vapor_password",
         database: Environment.get("DATABASE_NAME") ?? "vapor_database"
-    ), as: .mysql){{/fluent.db.is_mysql}}{{#fluent.db.is_mongo}}    try app.databases.use(DatabaseConfigurationFactory.mongo(
-        connectionString: Environment.get("DATABASE_URL") ?? "mongodb://localhost:27017/vapor_database"
-    ), as: .mongo){{/fluent.db.is_mongo}}{{#fluent.db.is_sqlite}}    app.databases.use(DatabaseConfigurationFactory.sqlite(.file("db.sqlite")), as: .sqlite){{/fluent.db.is_sqlite}}
+    ), as: .mysql){{/fluent.db.is_mysql}}{{#fluent.db.is_sqlite}}    app.databases.use(DatabaseConfigurationFactory.sqlite(.file("db.sqlite")), as: .sqlite){{/fluent.db.is_sqlite}}
 
     app.migrations.add(CreateTodo()){{/fluent}}{{#leaf}}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,12 +19,11 @@ volumes:
   db_data:{{/db.is_sqlite}}{{/fluent}}
 
 x-shared_environment: &shared_environment
-  LOG_LEVEL: ${LOG_LEVEL:-debug}{{#fluent}}{{^db.is_sqlite}}{{^db.is_mongo}}
+  LOG_LEVEL: ${LOG_LEVEL:-debug}{{#fluent}}{{^db.is_sqlite}}
   DATABASE_HOST: db
   DATABASE_NAME: vapor_database
   DATABASE_USERNAME: vapor_username
-  DATABASE_PASSWORD: vapor_password{{/db.is_mongo}}{{/db.is_sqlite}}{{#db.is_mongo}}
-  DATABASE_URL: mongodb://db:27017/vapor_database{{/db.is_mongo}}{{/fluent}}
+  DATABASE_PASSWORD: vapor_password{{/db.is_sqlite}}{{/fluent}}
   
 services:
   app:
@@ -82,11 +81,4 @@ services:
       MYSQL_DATABASE: vapor_database
       MYSQL_RANDOM_ROOT_PASSWORD: 'yes'
     ports:
-      - '3306:3306'{{/db.is_mysql}}{{#db.is_mongo}}
-  db:
-    image: mongo:latest
-    volumes:
-      - db_data:/data/db
-    restart: unless-stopped
-    ports:
-      - '27017:27017'{{/db.is_mongo}}{{/fluent}}
+      - '3306:3306'{{/db.is_mysql}}{{/fluent}}

--- a/manifest.yml
+++ b/manifest.yml
@@ -35,15 +35,6 @@ variables:
               version: "4.6.0"
               is_sqlite: true
               emoji: "\U0001FAB6"
-          - name: Mongo
-            description: ""
-            data:
-              module: Mongo
-              url: mongo
-              id: mongo
-              version: "1.3.1"
-              is_mongo: true
-              emoji: "\U0001F331"
   - name: leaf
     description: Would you like to use Leaf (templating)?
     type: bool


### PR DESCRIPTION
The MongoDB driver for Fluent 4 is deprecated, so we stop offering it as an option for new projects.