### PR TITLE
Update docker-compose.yml for latest PSQL and MySQL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,9 +21,9 @@ volumes:
 x-shared_environment: &shared_environment
   LOG_LEVEL: ${LOG_LEVEL:-debug}{{#fluent}}{{^db.is_sqlite}}
   DATABASE_HOST: db
-  DATABASE_NAME: vapor_database
-  DATABASE_USERNAME: vapor_username
-  DATABASE_PASSWORD: vapor_password{{/db.is_sqlite}}{{/fluent}}
+  DATABASE_NAME: &db_name vapor_database
+  DATABASE_USERNAME: &db_username vapor_username
+  DATABASE_PASSWORD: &db_password vapor_password{{/db.is_sqlite}}{{/fluent}}
   
 services:
   app:
@@ -61,24 +61,23 @@ services:
     deploy:
       replicas: 0{{#db.is_postgres}}
   db:
-    image: postgres:16-alpine
+    image: postgres:18-alpine
     volumes:
-      - db_data:/var/lib/postgresql/data/pgdata
+      - db_data:/var/lib/postgresql
     environment:
-      PGDATA: /var/lib/postgresql/data/pgdata
-      POSTGRES_USER: vapor_username
-      POSTGRES_PASSWORD: vapor_password
-      POSTGRES_DB: vapor_database
+      POSTGRES_USER: *db_username
+      POSTGRES_PASSWORD: *db_password
+      POSTGRES_DB: *db_name
     ports:
       - '5432:5432'{{/db.is_postgres}}{{#db.is_mysql}}
   db:
-    image: mysql:8
+    image: mysql:9-oracle
     volumes:
       - db_data:/var/lib/mysql
     environment:
-      MYSQL_USER: vapor_username
-      MYSQL_PASSWORD: vapor_password
-      MYSQL_DATABASE: vapor_database
-      MYSQL_RANDOM_ROOT_PASSWORD: 'yes'
+      MYSQL_USER: *db_username
+      MYSQL_PASSWORD: *db_password
+      MYSQL_DATABASE: *db_name
+      MYSQL_RANDOM_ROOT_PASSWORD: yes
     ports:
       - '3306:3306'{{/db.is_mysql}}{{/fluent}}


### PR DESCRIPTION
Also use a few anchors so the db username/password/name are only specified in one place. Note the changed data path for PostgreSQL, per https://hub.docker.com/_/postgres#pgdata ; as far as I can tell, there's no way to set up a configuration that will just work for both <=17 and 18+, thanks Postgres.